### PR TITLE
Add Docker configuration for all services

### DIFF
--- a/analysis-engine-service/Dockerfile
+++ b/analysis-engine-service/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.9-slim
+
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONDONTWRITEBODECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements file
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r rrequirements.txt
+
+# Copy application code
+COPY . .
+
+# Create non-root user
+RUN useradd -m appuser
+RUN chown -R appuser:appuser /app
+USER appuser
+
+# Expose port
+EXPOSE 8000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:8000/api/v1/health || exit 1
+
+# Run the application
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This PR adds Dockerfiles and docker-compose.yml files for all main services to enable running each service individually in Docker for isolated testing and debugging.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author